### PR TITLE
Guard RegisterExportBlacklist call against missing LibAT method

### DIFF
--- a/Core/Handlers/Profiles.lua
+++ b/Core/Handlers/Profiles.lua
@@ -9,6 +9,41 @@ local SPARTANUI_ADDON_ID = 'spartanui'
 -- Namespace blacklist
 local namespaceblacklist = { 'LibDualSpec-1.0' }
 
+-- Required LibAT ProfileManager API surface. If any of these are missing,
+-- the installed Libs-AddonTools is out of date and must be updated.
+local REQUIRED_PROFILE_MANAGER_API = {
+	'RegisterAddon',
+	'RegisterComposite',
+	'RegisterExportBlacklist',
+	'ShowImport',
+	'ShowExport',
+}
+
+---Check that LibAT ProfileManager is loaded and exposes the expected API.
+---@return boolean compatible True if the installed ProfileManager matches the expected API
+---@return string? reason Reason the API is unavailable (missing or outdated)
+local function IsProfileManagerCompatible()
+	if not (LibAT and LibAT.ProfileManager) then
+		return false, 'missing'
+	end
+	for _, method in ipairs(REQUIRED_PROFILE_MANAGER_API) do
+		if type(LibAT.ProfileManager[method]) ~= 'function' then
+			return false, 'outdated'
+		end
+	end
+	return true
+end
+
+---Show the appropriate error for an unavailable ProfileManager.
+---@param reason string 'missing' or 'outdated'
+local function ReportUnavailable(reason)
+	if reason == 'outdated' then
+		SUI:Error('Libs-AddonTools is out of date. Please update it to use profile import/export.')
+	else
+		SUI:Error('LibAT ProfileManager not available - profile import/export disabled')
+	end
+end
+
 ---Get list of all SpartanUI module namespaces for registration
 ---@return string[] namespaces List of namespace names
 local function GetNamespaceList()
@@ -30,60 +65,62 @@ end
 
 ---Open the LibAT ProfileManager in import mode for SpartanUI
 function module:ImportUI()
-	if LibAT and LibAT.ProfileManager then
+	local ok, reason = IsProfileManagerCompatible()
+	if ok then
 		LibAT.ProfileManager:ShowImport(SPARTANUI_ADDON_ID)
 	else
-		SUI:Error('LibAT ProfileManager not available')
+		ReportUnavailable(reason)
 	end
 end
 
 ---Open the LibAT ProfileManager in export mode for SpartanUI
 function module:ExportUI()
-	if LibAT and LibAT.ProfileManager then
+	local ok, reason = IsProfileManagerCompatible()
+	if ok then
 		LibAT.ProfileManager:ShowExport(SPARTANUI_ADDON_ID)
 	else
-		SUI:Error('LibAT ProfileManager not available')
+		ReportUnavailable(reason)
 	end
 end
 
 function module:OnEnable()
-	-- Register SpartanUI with LibAT ProfileManager
-	if LibAT and LibAT.ProfileManager then
-		local namespaces = GetNamespaceList()
-
-		LibAT.ProfileManager:RegisterAddon({
-			id = SPARTANUI_ADDON_ID,
-			name = 'SpartanUI',
-			db = SUI.SpartanUIDB,
-			namespaces = namespaces,
-			icon = 'Interface\\AddOns\\SpartanUI\\images\\Spartan-Helm',
-		})
-
-		-- Register composite bundle (full profile with action bars and UI positions)
-		LibAT.ProfileManager:RegisterComposite({
-			id = 'spartanui_full',
-			displayName = 'SpartanUI (Full Profile)',
-			description = 'Complete SUI setup including action bars and UI positions',
-			primaryAddonId = SPARTANUI_ADDON_ID,
-
-			-- Simple string IDs - ProfileManager's BuiltInSystems knows the rest
-			components = {
-				'bartender4', -- Built-in: knows addonId, displayName, availability
-				'editmode', -- Built-in: knows it's Retail-only, has export/import logic
-			},
-		})
-	else
-		SUI:Error('LibAT ProfileManager not available - profile import/export disabled')
+	local ok, reason = IsProfileManagerCompatible()
+	if not ok then
+		ReportUnavailable(reason)
+		return
 	end
+
+	-- Register SpartanUI with LibAT ProfileManager
+	local namespaces = GetNamespaceList()
+
+	LibAT.ProfileManager:RegisterAddon({
+		id = SPARTANUI_ADDON_ID,
+		name = 'SpartanUI',
+		db = SUI.SpartanUIDB,
+		namespaces = namespaces,
+		icon = 'Interface\\AddOns\\SpartanUI\\images\\Spartan-Helm',
+	})
+
+	-- Register composite bundle (full profile with action bars and UI positions)
+	LibAT.ProfileManager:RegisterComposite({
+		id = 'spartanui_full',
+		displayName = 'SpartanUI (Full Profile)',
+		description = 'Complete SUI setup including action bars and UI positions',
+		primaryAddonId = SPARTANUI_ADDON_ID,
+
+		-- Simple string IDs - ProfileManager's BuiltInSystems knows the rest
+		components = {
+			'bartender4', -- Built-in: knows addonId, displayName, availability
+			'editmode', -- Built-in: knows it's Retail-only, has export/import logic
+		},
+	})
 
 	-- Register export blacklist patterns
 	-- Paths are relative to namespace root: Namespace.profiles.ProfileName.key
-	if LibAT and LibAT.ProfileManager and LibAT.ProfileManager.RegisterExportBlacklist then
-		LibAT.ProfileManager:RegisterExportBlacklist({
-			'StopTalking.$global.history',
-			'PreyTracker.$global',
-		})
-	end
+	LibAT.ProfileManager:RegisterExportBlacklist({
+		'StopTalking.$global.history',
+		'PreyTracker.$global',
+	})
 
 	-- Register chat commands
 	SUI:AddChatCommand('export', module.ExportUI, 'Export your settings')

--- a/Core/Handlers/Profiles.lua
+++ b/Core/Handlers/Profiles.lua
@@ -78,7 +78,7 @@ function module:OnEnable()
 
 	-- Register export blacklist patterns
 	-- Paths are relative to namespace root: Namespace.profiles.ProfileName.key
-	if LibAT and LibAT.ProfileManager then
+	if LibAT and LibAT.ProfileManager and LibAT.ProfileManager.RegisterExportBlacklist then
 		LibAT.ProfileManager:RegisterExportBlacklist({
 			'StopTalking.$global.history',
 			'PreyTracker.$global',

--- a/Modules/MoveIt/MoverFactory.lua
+++ b/Modules/MoveIt/MoverFactory.lua
@@ -131,7 +131,10 @@ function MoveIt:CreateMover(parent, name, DisplayName, postdrag, groupName, widg
 
 	-- Validate anchor frame. Reject missing frames and frames that aren't rooted at UIParent
 	-- (e.g. textures or frames inside SpartanUI's scaled tree), as those cause position drift.
-	local anchorObj = type(anchor) == 'string' and _G[anchor] or anchor
+	local anchorObj = anchor
+	if type(anchor) == 'string' then
+		anchorObj = _G[anchor]
+	end
 	local anchorInvalid = not anchorObj
 	if anchorObj and type(anchor) == 'string' and anchor ~= 'UIParent' then
 		-- Walk up the parent chain looking for UIParent. If we hit SpartanUI (which is scaled),


### PR DESCRIPTION
Older LibAT ProfileManager versions lack RegisterExportBlacklist, which
produced an "attempt to call a nil value" error at Profiles.lua:82.
Check the method exists before invoking it.